### PR TITLE
feat: Add `do_not_read_environment` option.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+---
+name: Pull request
+about: Add new or update code to the project
+title: ''
+labels: ''
+assignees: ''
+
+---
+**Mark all relevant modifications for this new code.**
+## Contains
+- [ ] Breaking Changes
+- [ ] New/Update documentation
+- [ ] CI/CD modifications
+- [ ] '...'
+
+**A clear and concise description of all code changes**
+## Changes
+*  Add '...'
+*  Remove '...'
+*  Refactor '...'
+*  Update '...'
+
+**Inform which issue, task, story this code will resolve.**
+## Resolves
+Resolves '...'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	@poetry run pytest -v -x -p no:warnings --cov-report term-missing --cov=./stela
 
 ci:
-	poetry run yamllint --no-warnings . && poetry run pytest --cov=./stela --black --mypy --pydocstyle
+	@poetry run pytest --cov=./stela --black --mypy --pydocstyle
 
 format:
 	@poetry run black .

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ my_conf = settings["foo.bar"]
 # my_conf = "hello world"
 ```
 
+Also, you can define Stela to never get values from environment
+variables, only from dictionary:
+
+```toml
+[tools.stela]
+do_not_read_environment = true
+```
+
 ### How Stela handle more complex cases?
 
 Stela uses this lifecycle to handle the settings load:
@@ -247,6 +255,7 @@ environment_prefix = ""  # ex.: settings["foo.bar"'] looks for MY_PREFIX_FOO_BAR
 environment_suffix = ""  # ex.: settings["foo.bar"'] looks for FOO_BAR_MY_SUFFIX
 default_environment = ""
 evaluate_data = false
+do_not_read_environment = false
 show_logs = true  # as per loguru settings.
 ```
 

--- a/stela/stela_cut.py
+++ b/stela/stela_cut.py
@@ -107,7 +107,7 @@ class StelaCut(Cut):  # type: ignore
         :param kwargs: python keyword arguments
         :return: Any
         """
-        if not "[" in path:
+        if not "[" in path and not self.stela_options.do_not_read_environment:
             environment_variable = (
                 f"{self.stela_options.environment_prefix}"
                 f"{path.replace('.', '_')}"

--- a/stela/stela_options.py
+++ b/stela/stela_options.py
@@ -27,6 +27,7 @@ class StelaOptions:
     config_file_path: str = "."
     filenames: List[str] = field(default_factory=list)
     show_logs: bool = True
+    do_not_read_environment: bool = False
 
     def get_extensions(self) -> List[str]:
         """Return file extensions for project configuration files."""
@@ -88,6 +89,9 @@ class StelaOptions:
             ),
             "show_logs": cls.get_from_env_or_settings(
                 "show_logs", file_settings, cls.show_logs
+            ),
+            "do_not_read_environment": cls.get_from_env_or_settings(
+                "do_not_read_environment", file_settings, cls.do_not_read_environment
             ),
         }
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def stela_default_settings():
         "environment_suffix": "",
         "evaluate_data": False,
         "show_logs": True,
+        "do_not_read_environment": False,
     }
 
 

--- a/tests/test_read_config_files.py
+++ b/tests/test_read_config_files.py
@@ -52,3 +52,10 @@ def test_evaluated_value_from_environment(settings, monkeypatch):
     settings = stela_reload()
     assert settings["cat.names"] == ["Mr. Bigglesworth", "Grumpy Cat"]
     assert settings.get("cat.names") == ["Mr. Bigglesworth", "Grumpy Cat"]
+
+
+def test_do_not_read_from_environment(monkeypatch):
+    monkeypatch.setenv("STELA_DO_NOT_READ_ENVIRONMENT", True)
+    monkeypatch.setenv("NUMBER_OF_CATS", "10")
+    settings = stela_reload()
+    assert settings["app.number_of_cats"] == "1"

--- a/tests/test_stela_config.py
+++ b/tests/test_stela_config.py
@@ -22,6 +22,11 @@ def test_get_default_config(stela_default_settings, monkeypatch):
     )
     assert stela_config.evaluate_data == stela_default_settings["evaluate_data"]
     assert stela_config.config_file_path == stela_default_settings["config_file_path"]
+    assert (
+        stela_config.do_not_read_environment
+        == stela_default_settings["do_not_read_environment"]
+    )
+    assert stela_config.show_logs == stela_default_settings["show_logs"]
 
 
 def test_different_environments(monkeypatch):


### PR DESCRIPTION
This options will set Stela to always use the value from configuration files, instead replace him for the correspondent environment variable.