### PR TITLE
Remove rootpath from dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	@poetry run pytest -v -x -p no:warnings --cov-report term-missing --cov=./stela
 
 ci:
-	@poetry run pytest --cov=./stela --black --mypy --pydocstyle
+	@poetry run pytest --cov=./stela --black --mypy --pydocstyle --ignore=venv36 --ignore=venv37 --ignore=venv38
 
 format:
 	@poetry run black .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ license = "GPL-3.0"
 python = ">=3.0, !=3.1, !=3.2, !=3.3, !=3.4, !=3.5, ^3.6, <4"
 loguru = "*"
 pyyaml = "*"
-rootpath = "*"
 scalpl = "*"
 toml = "*"
 dataclasses = { version = "*", python = "<3.7" }

--- a/stela/detect.py
+++ b/stela/detect.py
@@ -1,0 +1,72 @@
+import os
+import re
+from os import listdir, path
+
+import six
+
+DEFAULT_PATH = "stela"
+DEFAULT_ROOT_FILENAME_MATCH_PATTERN = ".git|pyproject\.toml;"
+
+
+def detect(current_path=None, pattern=None):
+    """
+    Find project root path from specified file/directory path,
+    based on common project root file pattern.
+
+    Examples:
+
+        import rootpath
+
+        rootpath.detect()
+        rootpath.detect(__file__)
+        rootpath.detect('./src')
+
+    """
+
+    current_path = current_path or os.getcwd()
+    current_path = path.abspath(path.normpath(path.expanduser(current_path)))
+    pattern = pattern or DEFAULT_ROOT_FILENAME_MATCH_PATTERN
+
+    if not path.isdir(current_path):
+        current_path = path.dirname(current_path)
+
+    def find_root_path(current_path, pattern=None):
+        if isinstance(pattern, six.string_types):
+            pattern = re.compile(pattern)
+
+        detecting = True
+
+        found_more_files = None
+        found_root = None
+        found_system_root = None
+
+        file_names = None
+        root_file_names = None
+
+        while detecting:
+            file_names = listdir(current_path)
+            found_more_files = bool(len(file_names) > 0)
+
+            if not found_more_files:
+                detecting = False
+
+                return None
+
+            root_file_names = filter(pattern.match, file_names)
+            root_file_names = list(root_file_names)
+
+            found_root = bool(len(root_file_names) > 0)
+
+            if found_root:
+                detecting = False
+
+                return current_path
+
+            found_system_root = bool(current_path == path.sep)
+
+            if found_system_root:
+                return None
+
+            current_path = path.abspath(path.join(current_path, ".."))
+
+    return find_root_path(current_path, pattern)

--- a/stela/detect.py
+++ b/stela/detect.py
@@ -1,6 +1,7 @@
 import os
 import re
 from os import listdir, path
+from typing import Any, Optional
 
 import six
 
@@ -8,21 +9,12 @@ DEFAULT_PATH = "stela"
 DEFAULT_ROOT_FILENAME_MATCH_PATTERN = ".git|pyproject\.toml;"
 
 
-def detect(current_path=None, pattern=None):
-    """
+def detect(current_path: Optional[str] = None, pattern: Optional[str] = None) -> Any:
+    """Find Project Root.
+
     Find project root path from specified file/directory path,
     based on common project root file pattern.
-
-    Examples:
-
-        import rootpath
-
-        rootpath.detect()
-        rootpath.detect(__file__)
-        rootpath.detect('./src')
-
     """
-
     current_path = current_path or os.getcwd()
     current_path = path.abspath(path.normpath(path.expanduser(current_path)))
     pattern = pattern or DEFAULT_ROOT_FILENAME_MATCH_PATTERN
@@ -53,7 +45,7 @@ def detect(current_path=None, pattern=None):
                 return None
 
             root_file_names = filter(pattern.match, file_names)
-            root_file_names = list(root_file_names)
+            root_file_names = list(root_file_names)  # type: ignore
 
             found_root = bool(len(root_file_names) > 0)
 
@@ -69,4 +61,4 @@ def detect(current_path=None, pattern=None):
 
             current_path = path.abspath(path.join(current_path, ".."))
 
-    return find_root_path(current_path, pattern)
+    return find_root_path(current_path, pattern)  # type: ignore

--- a/stela/stela.py
+++ b/stela/stela.py
@@ -8,10 +8,10 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-import rootpath
 import toml
 import yaml
 
+from stela.detect import detect
 from stela.exceptions import StelaEnvironmentNotFoundError
 from stela.stela_cut import StelaCut
 from stela.stela_options import StelaOptions
@@ -38,7 +38,7 @@ class Stela:
         """
         from loguru import logger
 
-        path = rootpath.detect()
+        path = detect()
         for filename in options.filenames:
             filepath = Path(path).joinpath(self.options.config_file_path, filename)
             logger.debug(f"Looking for file {filepath}...")

--- a/stela/stela_options.py
+++ b/stela/stela_options.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import rootpath
 import toml
 
+from stela.detect import detect
 from stela.exceptions import StelaEnvironmentNotFoundError, StelaFileTypeError
 from stela.utils import StelaFileType
 
@@ -51,7 +51,7 @@ class StelaOptions:
     def get_config(cls) -> "StelaOptions":
         """Get config from pyproject.toml."""
 
-        path = rootpath.detect()
+        path = detect()
         filepath = Path(path).joinpath(f"pyproject.toml")
         if filepath.exists():
             toml_settings = toml.load(filepath)


### PR DESCRIPTION
This lib not work when dependencies are generated for AWS Lambda Layers (in dependencies/python folder). Current logic actually delete lib code inside this folder